### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,4 @@ This might only work with Firefox these days as browsers get more strict.
 # Useful Links
 
 * SQRL main page: https://www.grc.com/sqrl/sqrl.htm
-* SQRL link protocol to a site login page: https://www.grc.com/sqrl/protocol.htm and https://www.grc.com/sqrl/semantics.htm
-* SQRL web server expected behavior: https://www.grc.com/sqrl/server.htm
+* SQRL forum: https://sqrl.grc.com/


### PR DESCRIPTION
Remove outdated links. Steve has (on his podcast and one the forum, maybe not really on the main site...) explained that the links to subpages under grc.com/sqrl were removed because he was working on a "PDF version" of the important information. And now the main page has 4 documents. Likely still some parts missing there, that's when the forum comes in handy: https://sqrl.grc.com/